### PR TITLE
カードを外部アドオンで追加する機能

### DIFF
--- a/Common/GameSystem/CardRegistry.cs
+++ b/Common/GameSystem/CardRegistry.cs
@@ -9,11 +9,10 @@ using TerraTCG.Common.GameSystem.PackOpening;
 namespace TerraTCG.Common.GameSystem
 {
 
-	public  class CardRegistry : ModSystem
+	public class CardRegistry : ModSystem
 	{
 		public static CardRegistry Instance;
 
-		public static Action<Card> CardChanged;
 		public static Action CardChanges;
 
 		public override void Load()
@@ -24,7 +23,7 @@ namespace TerraTCG.Common.GameSystem
 		private static List<Card> _allCards;
 		public static List<Card> AllCards
 		{
-		 	get
+			get
 			{
 				_allCards ??= ModContent.GetContent<BaseCardTemplate>()
 							.Select(t => t.Card)

--- a/Common/GameSystem/CardRegistry.cs
+++ b/Common/GameSystem/CardRegistry.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Terraria.ModLoader;
 using TerraTCG.Common.GameSystem.CardData;
@@ -13,7 +12,7 @@ namespace TerraTCG.Common.GameSystem
 	{
 		public static CardRegistry Instance;
 
-		public static event Action OnCardsAdded;
+		public static bool RequestAddCards = false;
 
 		public override void Load()
 		{
@@ -39,7 +38,7 @@ namespace TerraTCG.Common.GameSystem
 			foreach (Card card in cards)
 				if (card.IsCollectable)
 					CardPools.CollectableCards.Add(card);
-			OnCardsAdded.Invoke();
+			RequestAddCards = true;
 		}
 	}
 }

--- a/Common/GameSystem/CardRegistry.cs
+++ b/Common/GameSystem/CardRegistry.cs
@@ -13,11 +13,14 @@ namespace TerraTCG.Common.GameSystem
 	{
 		public static CardRegistry Instance;
 
+		public static bool needsReconstruction = false;
+
 		public static event Action OnCardsAdded;
 
 		public override void Load()
 		{
 			Instance = this;
+			OnCardsAdded += () => needsReconstruction = true;
 		}
 
 		private static List<Card> _allCards;
@@ -33,7 +36,7 @@ namespace TerraTCG.Common.GameSystem
 		}
 
 
-		public static void AddCards(params Card[] cards)
+		public void AddCards(params Card[] cards)
 		{
 			AllCards.AddRange(cards);
 			foreach (Card card in cards)

--- a/Common/GameSystem/CardRegistry.cs
+++ b/Common/GameSystem/CardRegistry.cs
@@ -32,21 +32,14 @@ namespace TerraTCG.Common.GameSystem
 			}
 		}
 
-		public static void AddCard(Card card)
-		{
-			_allCards.Add(card);
-			if (card.IsCollectable)
-				CardPools.CollectableCards.Add(card);
-			CardChanges.Invoke();
-		}
 
-		public static void AddCard(params Card[] cards)
+		public static void AddCards(params Card[] cards)
 		{
 			_allCards.AddRange(cards);
 			foreach (Card card in cards)
 				if (card.IsCollectable)
 					CardPools.CollectableCards.Add(card);
-			CardChanges.Invoke();
+			OnCardsAdded.Invoke();
 		}
 	}
 }

--- a/Common/GameSystem/CardRegistry.cs
+++ b/Common/GameSystem/CardRegistry.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Terraria.ModLoader;
 using TerraTCG.Common.GameSystem.CardData;
@@ -6,8 +7,18 @@ using TerraTCG.Common.GameSystem.GameState;
 
 namespace TerraTCG.Common.GameSystem
 {
-	public class CardRegistry : ModSystem
+
+	public  class CardRegistry : ModSystem
 	{
+		public static CardRegistry Instance;
+
+		public static Action<Card> CardChanged;
+
+		public override void Load()
+		{
+			Instance = this;
+		}
+
 		private static List<Card> _allCards;
 		public static List<Card> AllCards
 		{

--- a/Common/GameSystem/CardRegistry.cs
+++ b/Common/GameSystem/CardRegistry.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Terraria.ModLoader;
 using TerraTCG.Common.GameSystem.CardData;
@@ -12,7 +13,7 @@ namespace TerraTCG.Common.GameSystem
 	{
 		public static CardRegistry Instance;
 
-		public static bool RequestAddCards = false;
+		public static event Action OnCardsAdded;
 
 		public override void Load()
 		{
@@ -38,7 +39,7 @@ namespace TerraTCG.Common.GameSystem
 			foreach (Card card in cards)
 				if (card.IsCollectable)
 					CardPools.CollectableCards.Add(card);
-			RequestAddCards = true;
+			OnCardsAdded.Invoke();
 		}
 	}
 }

--- a/Common/GameSystem/CardRegistry.cs
+++ b/Common/GameSystem/CardRegistry.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Terraria.ModLoader;
 using TerraTCG.Common.GameSystem.CardData;
 using TerraTCG.Common.GameSystem.GameState;
+using TerraTCG.Common.GameSystem.PackOpening;
 
 namespace TerraTCG.Common.GameSystem
 {
@@ -13,6 +14,7 @@ namespace TerraTCG.Common.GameSystem
 		public static CardRegistry Instance;
 
 		public static Action<Card> CardChanged;
+		public static Action CardChanges;
 
 		public override void Load()
 		{
@@ -34,11 +36,18 @@ namespace TerraTCG.Common.GameSystem
 		public static void AddCard(Card card)
 		{
 			_allCards.Add(card);
+			if (card.IsCollectable)
+				CardPools.CollectableCards.Add(card);
+			CardChanges.Invoke();
 		}
 
 		public static void AddCard(params Card[] cards)
 		{
 			_allCards.AddRange(cards);
+			foreach (Card card in cards)
+				if (card.IsCollectable)
+					CardPools.CollectableCards.Add(card);
+			CardChanges.Invoke();
 		}
 	}
 }

--- a/Common/GameSystem/CardRegistry.cs
+++ b/Common/GameSystem/CardRegistry.cs
@@ -35,11 +35,22 @@ namespace TerraTCG.Common.GameSystem
 
 		public static void AddCards(params Card[] cards)
 		{
-			AllCards.AddRange(cards);
+			bool cardAdded = false;
+
 			foreach (Card card in cards)
+			{
+				if (AllCards.Contains(card))
+					continue;
+
+				cardAdded = true;
+				AllCards.Add(card);
+
 				if (card.IsCollectable)
 					CardPools.CollectableCards.Add(card);
-			OnCardsAdded?.Invoke();
+			}
+
+			if (cardAdded)
+				OnCardsAdded?.Invoke();
 		}
 	}
 }

--- a/Common/GameSystem/CardRegistry.cs
+++ b/Common/GameSystem/CardRegistry.cs
@@ -35,7 +35,7 @@ namespace TerraTCG.Common.GameSystem
 
 		public static void AddCards(params Card[] cards)
 		{
-			_allCards.AddRange(cards);
+			AllCards.AddRange(cards);
 			foreach (Card card in cards)
 				if (card.IsCollectable)
 					CardPools.CollectableCards.Add(card);

--- a/Common/GameSystem/CardRegistry.cs
+++ b/Common/GameSystem/CardRegistry.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Terraria.ModLoader;
+using TerraTCG.Common.GameSystem.CardData;
+using TerraTCG.Common.GameSystem.GameState;
+
+namespace TerraTCG.Common.GameSystem
+{
+	public class CardRegistry : ModSystem
+	{
+		private static List<Card> _allCards;
+		public static List<Card> AllCards
+		{
+		 	get
+			{
+				_allCards ??= ModContent.GetContent<BaseCardTemplate>()
+							.Select(t => t.Card)
+							.ToList();
+				return _allCards;
+			}
+		}
+
+		public static void AddCard(Card card)
+		{
+			_allCards.Add(card);
+		}
+
+		public static void AddCard(params Card[] cards)
+		{
+			_allCards.AddRange(cards);
+		}
+	}
+}

--- a/Common/GameSystem/CardRegistry.cs
+++ b/Common/GameSystem/CardRegistry.cs
@@ -13,7 +13,7 @@ namespace TerraTCG.Common.GameSystem
 	{
 		public static CardRegistry Instance;
 
-		public static Action CardChanges;
+		public static event Action OnCardsAdded;
 
 		public override void Load()
 		{

--- a/Common/GameSystem/CardRegistry.cs
+++ b/Common/GameSystem/CardRegistry.cs
@@ -13,14 +13,11 @@ namespace TerraTCG.Common.GameSystem
 	{
 		public static CardRegistry Instance;
 
-		public static bool needsReconstruction = false;
-
 		public static event Action OnCardsAdded;
 
 		public override void Load()
 		{
 			Instance = this;
-			OnCardsAdded += () => needsReconstruction = true;
 		}
 
 		private static List<Card> _allCards;
@@ -36,13 +33,13 @@ namespace TerraTCG.Common.GameSystem
 		}
 
 
-		public void AddCards(params Card[] cards)
+		public static void AddCards(params Card[] cards)
 		{
 			AllCards.AddRange(cards);
 			foreach (Card card in cards)
 				if (card.IsCollectable)
 					CardPools.CollectableCards.Add(card);
-			OnCardsAdded.Invoke();
+			OnCardsAdded?.Invoke();
 		}
 	}
 }

--- a/Common/GameSystem/Drawing/CardOverlayRenderer.cs
+++ b/Common/GameSystem/Drawing/CardOverlayRenderer.cs
@@ -1,6 +1,11 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using Terraria;
 using Terraria.Graphics.Shaders;
 using Terraria.ID;
@@ -11,15 +16,15 @@ namespace TerraTCG.Common.GameSystem.Drawing
 {
 	public delegate void DrawZoneNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects);
 	public class CardOverlayRenderer : ModSystem
-	{
-		public static CardOverlayRenderer Instance => ModContent.GetInstance<CardOverlayRenderer>();
+    {
+        public static CardOverlayRenderer Instance => ModContent.GetInstance<CardOverlayRenderer>();
 
 
 		private void DrawZoneNPC(
 			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float rotation, float scale, SpriteEffects effects)
 		{
-			var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
-			var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
+            var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
+            var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
 			if (card.Template.NPCID == 0 && card.Template.Mod != Mod.Name)
 			{
 				texture = card.Template.OverlayTexture;
@@ -29,62 +34,62 @@ namespace TerraTCG.Common.GameSystem.Drawing
 			spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, rotation, origin, scale, effects, 0);
 		}
 
-		public void DefaultDrawZoneNPC(
-			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-		{
-			DrawZoneNPC(spriteBatch, card, position, frame, color, 0, scale, effects);
-		}
+        public void DefaultDrawZoneNPC(
+            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+        {
+			DrawZoneNPC(spriteBatch, card, position, frame, color, 0, scale,effects);
+        }
 
-		public void DrawFlippedZoneNPC(
-			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-		{
+        public void DrawFlippedZoneNPC(
+            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+        {
 			DrawZoneNPC(spriteBatch, card, position, frame, color, 0, scale, effects | SpriteEffects.FlipVertically);
-		}
-		public void DrawRotatedZoneNPC(
-			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-		{
+        }
+        public void DrawRotatedZoneNPC(
+            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+        {
 			DrawZoneNPC(spriteBatch, card, position, frame, color, 0, scale, (effects | SpriteEffects.FlipVertically) ^ SpriteEffects.FlipHorizontally);
-		}
+        }
 
-		public DrawZoneNPC DrawSlimeNPC(float slimeScale, Color slimeColor)
-		{
-			return (SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects) =>
-			{
-				var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
-				var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
-				var origin = new Vector2(bounds.Width / 2, bounds.Height);
-				spriteBatch.Draw(texture.Value, position, bounds, slimeColor, 0, origin, scale * slimeScale, effects, 0);
-			};
-		}
+        public DrawZoneNPC DrawSlimeNPC(float slimeScale, Color slimeColor)
+        {
+            return (SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects) =>
+            {
+                var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
+                var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
+                var origin = new Vector2(bounds.Width / 2, bounds.Height);
+                spriteBatch.Draw(texture.Value, position, bounds, slimeColor, 0, origin, scale * slimeScale, effects, 0);
+            };
+        }
 
-		public void DrawMimicNPC(
-			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-		{
-			// only cycle through the golden mimic's frames, not all 3.
-			frame = (frame % (Main.npcFrameCount[card.Template.NPCID] / 3)) + Main.npcFrameCount[card.Template.NPCID] / 3;
-			DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
-		}
+        public void DrawMimicNPC(
+            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+        {
+            // only cycle through the golden mimic's frames, not all 3.
+            frame = (frame % (Main.npcFrameCount[card.Template.NPCID] / 3)) + Main.npcFrameCount[card.Template.NPCID] / 3;
+            DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
+        }
 
-		public void DrawKingSlimeNPC(
-			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-		{
-			scale *= 0.5f;
-			DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
-			var npcTexture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID).Value;
-			var npcBounds = npcTexture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
-			var texture = TextureCache.Instance.KingSlimeCrown;
-			var bounds = texture.Value.Bounds;
-			var origin = new Vector2(bounds.Width / 2, bounds.Height);
-			spriteBatch.Draw(texture.Value, position - Vector2.UnitY * npcBounds.Height * 0.75f * scale, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
-		}
+        public void DrawKingSlimeNPC(
+            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+        {
+            scale *= 0.5f;
+            DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
+            var npcTexture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID).Value;
+            var npcBounds = npcTexture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
+            var texture = TextureCache.Instance.KingSlimeCrown;
+            var bounds = texture.Value.Bounds;
+            var origin = new Vector2(bounds.Width / 2, bounds.Height);
+            spriteBatch.Draw(texture.Value, position - Vector2.UnitY * npcBounds.Height * 0.75f * scale, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
+        }
 
-		public void DrawQueenSlimeNPC(
-			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-		{
+        public void DrawQueenSlimeNPC(
+            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+        {
 			// Significantly more complicated than King Slime
 			scale *= 0.75f;
-			var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
-			var npcBounds = texture.Frame(2, 16, 0, frame % 5);
+            var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
+            var npcBounds = texture.Frame(2, 16, 0, frame % 5);
 
 			// Draw the interior crystal
 			var crystalTexture = TextureCache.Instance.QueenSlimeCore;
@@ -97,14 +102,14 @@ namespace TerraTCG.Common.GameSystem.Drawing
 			spriteBatch.End();
 			spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone, null, Main.UIScaleMatrix);
 
-			origin = new Vector2(npcBounds.Width / 2, npcBounds.Height);
+            origin = new Vector2(npcBounds.Width / 2, npcBounds.Height);
 
 			GameShaders.Misc["QueenSlime"].Apply();
-			spriteBatch.Draw(texture.Value, position, npcBounds, color ?? Color.White, 0, origin, scale, effects, 0);
+            spriteBatch.Draw(texture.Value, position, npcBounds, color ?? Color.White, 0, origin, scale, effects, 0);
 
 			spriteBatch.End();
-			spriteBatch.Begin(
-				SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.LinearClamp, DepthStencilState.None, RasterizerState.CullCounterClockwise, null, Main.UIScaleMatrix);
+            spriteBatch.Begin(
+                SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.LinearClamp, DepthStencilState.None, RasterizerState.CullCounterClockwise, null, Main.UIScaleMatrix);
 
 			// Draw the crown
 			var crownTexture = TextureCache.Instance.QueenSlimeCrown;
@@ -114,55 +119,54 @@ namespace TerraTCG.Common.GameSystem.Drawing
 		}
 
 		public void DrawGoblinArcherNPC(
-			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-		{
+            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+        {
 			frame = (frame % 12) + 5;
-			DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
-		}
+            DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
+        }
 
-		public void DrawQueenBeeNPC(
-			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-		{
-			scale *= 0.5f;
+        public void DrawQueenBeeNPC(
+            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+        {
+            scale *= 0.5f;
 			frame = (frame % 8) + 4;
-			DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
-		}
+            DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
+        }
 
-		public void DrawBrainOfCthulhuNPC(
-			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-		{
-			scale *= 0.5f;
-			frame = (frame % 6) + 6;
-			DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
-		}
+        public void DrawBrainOfCthulhuNPC(
+            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+        {
+            scale *= 0.5f;
+			frame = (frame %6) + 6;
+            DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
+        }
 
 		internal void DrawBOCNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
-			scale *= 0.5f;
-			frame = (frame % 4) + 4;
-			DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
+            scale *= 0.5f;
+			frame = (frame %4) + 4;
+            DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
 		}
 
 		internal void DrawEOCNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
 			// TODO we want to get the PlacedCard to do the "transform" animation
-			scale *= 0.75f;
+            scale *= 0.75f;
 			if (card.CurrentHealth <= (card.Template.MaxHealth + 1) / 2)
 			{
 				frame = (frame % 3) + 3;
-			}
-			else
+			} else
 			{
 				frame %= 3;
 			}
 			// TODO why do we need to shift position?
-			DefaultDrawZoneNPC(spriteBatch, card, position + new Vector2(0, 48 * scale), frame, color, scale, effects | SpriteEffects.FlipVertically);
+            DefaultDrawZoneNPC(spriteBatch, card, position + new Vector2(0, 48 * scale), frame, color, scale, effects | SpriteEffects.FlipVertically);
 		}
 
 		internal void DrawSkeletronPrimeNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
 			// TODO we want to get the PlacedCard to do the "transform" animation
-			DefaultDrawZoneNPC(spriteBatch, card, position + new Vector2(0, 24 * scale), frame, color, scale, effects);
+            DefaultDrawZoneNPC(spriteBatch, card, position + new Vector2(0, 24 * scale), frame, color, scale, effects);
 		}
 
 		internal void DrawNoOpNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
@@ -171,7 +175,7 @@ namespace TerraTCG.Common.GameSystem.Drawing
 
 		internal void DrawWOFNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
-			scale *= 0.75f;
+            scale *= 0.75f;
 			// Textures
 			var textureCache = TextureCache.Instance;
 			var mouthTexture = textureCache.GetNPCTexture(NPCID.WallofFlesh);
@@ -197,7 +201,7 @@ namespace TerraTCG.Common.GameSystem.Drawing
 			// spriteBatch.Draw(wallTexture.Value, position + xOffset, wallBounds, color ?? Color.White, MathF.PI/2, wallOrigin, scale, effects, 0);
 			spriteBatch.Draw(mouthTexture.Value, position - yOffset, mouthBounds, color ?? Color.White, rotation, mouthOrigin, scale, effects, 0);
 
-			for (int i = -1; i <= 1; i += 2)
+			for(int i = -1; i <= 1; i+=2)
 			{
 				var eyeOffset = new Vector2(i * scale * (wallBounds.Height - eyeBounds.Height) / 2, 0);
 				spriteBatch.Draw(eyeTexture.Value, position + eyeOffset - yOffset, eyeBounds, color ?? Color.White, rotation, eyeOrigin, scale, effects, 0);
@@ -207,20 +211,20 @@ namespace TerraTCG.Common.GameSystem.Drawing
 		public void DrawBestiaryZoneNPC(
 			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
-			var texture = TextureCache.Instance.GetBestiaryTexture(card.Template.NPCID);
-			var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
-			var origin = new Vector2(bounds.Width / 2, bounds.Height);
-			spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
+            var texture = TextureCache.Instance.GetBestiaryTexture(card.Template.NPCID);
+            var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
+            var origin = new Vector2(bounds.Width / 2, bounds.Height);
+            spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
 		}
 
 		internal void DrawDeerclopsNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
-			scale *= 0.75f;
+            scale *= 0.75f;
 			frame %= 10;
-			var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
-			var bounds = texture.Frame(5, 5, frame / 5, frame % 5);
-			var origin = new Vector2(bounds.Width / 2, bounds.Height);
-			spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
+            var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
+            var bounds = texture.Frame(5, 5, frame / 5, frame % 5);
+            var origin = new Vector2(bounds.Width / 2, bounds.Height);
+            spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
 		}
 
 		internal void DrawDestroyerNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
@@ -232,10 +236,10 @@ namespace TerraTCG.Common.GameSystem.Drawing
 
 		internal void DrawStaticOverlayNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
-			var texture = TextureCache.Instance.GetStaticNPCTexture(card.Template.NPCID);
+            var texture = TextureCache.Instance.GetStaticNPCTexture(card.Template.NPCID);
 			var bounds = texture.Value.Bounds;
-			var origin = new Vector2(bounds.Width / 2, bounds.Height);
-			spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
+            var origin = new Vector2(bounds.Width / 2, bounds.Height);
+            spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
 		}
 	}
 }

--- a/Common/GameSystem/Drawing/CardOverlayRenderer.cs
+++ b/Common/GameSystem/Drawing/CardOverlayRenderer.cs
@@ -1,11 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using ReLogic.Content;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
 using Terraria.Graphics.Shaders;
 using Terraria.ID;
@@ -16,15 +11,15 @@ namespace TerraTCG.Common.GameSystem.Drawing
 {
 	public delegate void DrawZoneNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects);
 	public class CardOverlayRenderer : ModSystem
-    {
-        public static CardOverlayRenderer Instance => ModContent.GetInstance<CardOverlayRenderer>();
+	{
+		public static CardOverlayRenderer Instance => ModContent.GetInstance<CardOverlayRenderer>();
 
 
 		private void DrawZoneNPC(
 			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float rotation, float scale, SpriteEffects effects)
 		{
-            var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
-            var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
+			var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
+			var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
 			if (card.Template.NPCID == 0 && card.Template.Mod != Mod.Name)
 			{
 				texture = card.Template.OverlayTexture;
@@ -34,62 +29,62 @@ namespace TerraTCG.Common.GameSystem.Drawing
 			spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, rotation, origin, scale, effects, 0);
 		}
 
-        public void DefaultDrawZoneNPC(
-            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-        {
-			DrawZoneNPC(spriteBatch, card, position, frame, color, 0, scale,effects);
-        }
+		public void DefaultDrawZoneNPC(
+			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+		{
+			DrawZoneNPC(spriteBatch, card, position, frame, color, 0, scale, effects);
+		}
 
-        public void DrawFlippedZoneNPC(
-            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-        {
+		public void DrawFlippedZoneNPC(
+			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+		{
 			DrawZoneNPC(spriteBatch, card, position, frame, color, 0, scale, effects | SpriteEffects.FlipVertically);
-        }
-        public void DrawRotatedZoneNPC(
-            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-        {
+		}
+		public void DrawRotatedZoneNPC(
+			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+		{
 			DrawZoneNPC(spriteBatch, card, position, frame, color, 0, scale, (effects | SpriteEffects.FlipVertically) ^ SpriteEffects.FlipHorizontally);
-        }
+		}
 
-        public DrawZoneNPC DrawSlimeNPC(float slimeScale, Color slimeColor)
-        {
-            return (SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects) =>
-            {
-                var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
-                var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
-                var origin = new Vector2(bounds.Width / 2, bounds.Height);
-                spriteBatch.Draw(texture.Value, position, bounds, slimeColor, 0, origin, scale * slimeScale, effects, 0);
-            };
-        }
+		public DrawZoneNPC DrawSlimeNPC(float slimeScale, Color slimeColor)
+		{
+			return (SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects) =>
+			{
+				var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
+				var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
+				var origin = new Vector2(bounds.Width / 2, bounds.Height);
+				spriteBatch.Draw(texture.Value, position, bounds, slimeColor, 0, origin, scale * slimeScale, effects, 0);
+			};
+		}
 
-        public void DrawMimicNPC(
-            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-        {
-            // only cycle through the golden mimic's frames, not all 3.
-            frame = (frame % (Main.npcFrameCount[card.Template.NPCID] / 3)) + Main.npcFrameCount[card.Template.NPCID] / 3;
-            DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
-        }
+		public void DrawMimicNPC(
+			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+		{
+			// only cycle through the golden mimic's frames, not all 3.
+			frame = (frame % (Main.npcFrameCount[card.Template.NPCID] / 3)) + Main.npcFrameCount[card.Template.NPCID] / 3;
+			DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
+		}
 
-        public void DrawKingSlimeNPC(
-            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-        {
-            scale *= 0.5f;
-            DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
-            var npcTexture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID).Value;
-            var npcBounds = npcTexture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
-            var texture = TextureCache.Instance.KingSlimeCrown;
-            var bounds = texture.Value.Bounds;
-            var origin = new Vector2(bounds.Width / 2, bounds.Height);
-            spriteBatch.Draw(texture.Value, position - Vector2.UnitY * npcBounds.Height * 0.75f * scale, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
-        }
+		public void DrawKingSlimeNPC(
+			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+		{
+			scale *= 0.5f;
+			DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
+			var npcTexture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID).Value;
+			var npcBounds = npcTexture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
+			var texture = TextureCache.Instance.KingSlimeCrown;
+			var bounds = texture.Value.Bounds;
+			var origin = new Vector2(bounds.Width / 2, bounds.Height);
+			spriteBatch.Draw(texture.Value, position - Vector2.UnitY * npcBounds.Height * 0.75f * scale, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
+		}
 
-        public void DrawQueenSlimeNPC(
-            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-        {
+		public void DrawQueenSlimeNPC(
+			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+		{
 			// Significantly more complicated than King Slime
 			scale *= 0.75f;
-            var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
-            var npcBounds = texture.Frame(2, 16, 0, frame % 5);
+			var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
+			var npcBounds = texture.Frame(2, 16, 0, frame % 5);
 
 			// Draw the interior crystal
 			var crystalTexture = TextureCache.Instance.QueenSlimeCore;
@@ -102,14 +97,14 @@ namespace TerraTCG.Common.GameSystem.Drawing
 			spriteBatch.End();
 			spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone, null, Main.UIScaleMatrix);
 
-            origin = new Vector2(npcBounds.Width / 2, npcBounds.Height);
+			origin = new Vector2(npcBounds.Width / 2, npcBounds.Height);
 
 			GameShaders.Misc["QueenSlime"].Apply();
-            spriteBatch.Draw(texture.Value, position, npcBounds, color ?? Color.White, 0, origin, scale, effects, 0);
+			spriteBatch.Draw(texture.Value, position, npcBounds, color ?? Color.White, 0, origin, scale, effects, 0);
 
 			spriteBatch.End();
-            spriteBatch.Begin(
-                SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.LinearClamp, DepthStencilState.None, RasterizerState.CullCounterClockwise, null, Main.UIScaleMatrix);
+			spriteBatch.Begin(
+				SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.LinearClamp, DepthStencilState.None, RasterizerState.CullCounterClockwise, null, Main.UIScaleMatrix);
 
 			// Draw the crown
 			var crownTexture = TextureCache.Instance.QueenSlimeCrown;
@@ -119,54 +114,55 @@ namespace TerraTCG.Common.GameSystem.Drawing
 		}
 
 		public void DrawGoblinArcherNPC(
-            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-        {
+			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+		{
 			frame = (frame % 12) + 5;
-            DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
-        }
+			DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
+		}
 
-        public void DrawQueenBeeNPC(
-            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-        {
-            scale *= 0.5f;
+		public void DrawQueenBeeNPC(
+			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+		{
+			scale *= 0.5f;
 			frame = (frame % 8) + 4;
-            DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
-        }
+			DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
+		}
 
-        public void DrawBrainOfCthulhuNPC(
-            SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
-        {
-            scale *= 0.5f;
-			frame = (frame %6) + 6;
-            DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
-        }
+		public void DrawBrainOfCthulhuNPC(
+			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
+		{
+			scale *= 0.5f;
+			frame = (frame % 6) + 6;
+			DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
+		}
 
 		internal void DrawBOCNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
-            scale *= 0.5f;
-			frame = (frame %4) + 4;
-            DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
+			scale *= 0.5f;
+			frame = (frame % 4) + 4;
+			DefaultDrawZoneNPC(spriteBatch, card, position, frame, color, scale, effects);
 		}
 
 		internal void DrawEOCNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
 			// TODO we want to get the PlacedCard to do the "transform" animation
-            scale *= 0.75f;
+			scale *= 0.75f;
 			if (card.CurrentHealth <= (card.Template.MaxHealth + 1) / 2)
 			{
 				frame = (frame % 3) + 3;
-			} else
+			}
+			else
 			{
 				frame %= 3;
 			}
 			// TODO why do we need to shift position?
-            DefaultDrawZoneNPC(spriteBatch, card, position + new Vector2(0, 48 * scale), frame, color, scale, effects | SpriteEffects.FlipVertically);
+			DefaultDrawZoneNPC(spriteBatch, card, position + new Vector2(0, 48 * scale), frame, color, scale, effects | SpriteEffects.FlipVertically);
 		}
 
 		internal void DrawSkeletronPrimeNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
 			// TODO we want to get the PlacedCard to do the "transform" animation
-            DefaultDrawZoneNPC(spriteBatch, card, position + new Vector2(0, 24 * scale), frame, color, scale, effects);
+			DefaultDrawZoneNPC(spriteBatch, card, position + new Vector2(0, 24 * scale), frame, color, scale, effects);
 		}
 
 		internal void DrawNoOpNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
@@ -175,7 +171,7 @@ namespace TerraTCG.Common.GameSystem.Drawing
 
 		internal void DrawWOFNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
-            scale *= 0.75f;
+			scale *= 0.75f;
 			// Textures
 			var textureCache = TextureCache.Instance;
 			var mouthTexture = textureCache.GetNPCTexture(NPCID.WallofFlesh);
@@ -201,7 +197,7 @@ namespace TerraTCG.Common.GameSystem.Drawing
 			// spriteBatch.Draw(wallTexture.Value, position + xOffset, wallBounds, color ?? Color.White, MathF.PI/2, wallOrigin, scale, effects, 0);
 			spriteBatch.Draw(mouthTexture.Value, position - yOffset, mouthBounds, color ?? Color.White, rotation, mouthOrigin, scale, effects, 0);
 
-			for(int i = -1; i <= 1; i+=2)
+			for (int i = -1; i <= 1; i += 2)
 			{
 				var eyeOffset = new Vector2(i * scale * (wallBounds.Height - eyeBounds.Height) / 2, 0);
 				spriteBatch.Draw(eyeTexture.Value, position + eyeOffset - yOffset, eyeBounds, color ?? Color.White, rotation, eyeOrigin, scale, effects, 0);
@@ -211,20 +207,20 @@ namespace TerraTCG.Common.GameSystem.Drawing
 		public void DrawBestiaryZoneNPC(
 			SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
-            var texture = TextureCache.Instance.GetBestiaryTexture(card.Template.NPCID);
-            var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
-            var origin = new Vector2(bounds.Width / 2, bounds.Height);
-            spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
+			var texture = TextureCache.Instance.GetBestiaryTexture(card.Template.NPCID);
+			var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
+			var origin = new Vector2(bounds.Width / 2, bounds.Height);
+			spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
 		}
 
 		internal void DrawDeerclopsNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
-            scale *= 0.75f;
+			scale *= 0.75f;
 			frame %= 10;
-            var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
-            var bounds = texture.Frame(5, 5, frame / 5, frame % 5);
-            var origin = new Vector2(bounds.Width / 2, bounds.Height);
-            spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
+			var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
+			var bounds = texture.Frame(5, 5, frame / 5, frame % 5);
+			var origin = new Vector2(bounds.Width / 2, bounds.Height);
+			spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
 		}
 
 		internal void DrawDestroyerNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
@@ -236,10 +232,10 @@ namespace TerraTCG.Common.GameSystem.Drawing
 
 		internal void DrawStaticOverlayNPC(SpriteBatch spriteBatch, PlacedCard card, Vector2 position, int frame, Color? color, float scale, SpriteEffects effects)
 		{
-            var texture = TextureCache.Instance.GetStaticNPCTexture(card.Template.NPCID);
+			var texture = TextureCache.Instance.GetStaticNPCTexture(card.Template.NPCID);
 			var bounds = texture.Value.Bounds;
-            var origin = new Vector2(bounds.Width / 2, bounds.Height);
-            spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
+			var origin = new Vector2(bounds.Width / 2, bounds.Height);
+			spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, 0, origin, scale, effects, 0);
 		}
 	}
 }

--- a/Common/GameSystem/Drawing/CardOverlayRenderer.cs
+++ b/Common/GameSystem/Drawing/CardOverlayRenderer.cs
@@ -26,10 +26,12 @@ namespace TerraTCG.Common.GameSystem.Drawing
             var texture = TextureCache.Instance.GetNPCTexture(card.Template.NPCID);
             var bounds = texture.Frame(1, Main.npcFrameCount[card.Template.NPCID], 0, frame);
 			if (card.Template.NPCID == 0 && card.Template.Mod != Mod.Name)
+			{
 				texture = card.Template.OverlayTexture;
-			    bounds = texture.Frame(1, card.Template.OverlayFrame, 0, frame);
-            var origin = new Vector2(bounds.Width / 2, bounds.Height);
-            spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, rotation, origin, scale, effects, 0);
+				bounds = texture.Frame(1, card.Template.OverlayFrame, 0, frame);
+			}
+			var origin = new Vector2(bounds.Width / 2, bounds.Height);
+			spriteBatch.Draw(texture.Value, position, bounds, color ?? Color.White, rotation, origin, scale, effects, 0);
 		}
 
         public void DefaultDrawZoneNPC(

--- a/Common/GameSystem/GameState/Card.cs
+++ b/Common/GameSystem/GameState/Card.cs
@@ -1,55 +1,60 @@
-﻿using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.GameContent;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using TerraTCG.Common.GameSystem.Drawing;
 using TerraTCG.Common.GameSystem.GameState.GameActions;
 using TerraTCG.Common.GameSystem.GameState.Modifiers;
+using TerraTCG.Common.Util;
 
 namespace TerraTCG.Common.GameSystem.GameState
 {
 	public enum CardType
-	{
-		CREATURE,
-		ITEM,
-		TOWNSFOLK
-	}
+    {
+        CREATURE,
+        ITEM,
+        TOWNSFOLK
+    }
 
 	public enum CardSubtype
-	{
-		// Empty value
-		NONE,
-		// Creature Supertypes
-		EXPERT,
-		BOSS,
-		// Creature Roles
-		FIGHTER,
-		SCOUT,
-		DEFENDER,
-		SLIME,
-		CRITTER,
-		CASTER,
+    {
+        // Empty value
+        NONE,
+        // Creature Supertypes
+        EXPERT,
+        BOSS,
+        // Creature Roles
+        FIGHTER,
+        SCOUT,
+        DEFENDER,
+        SLIME,
+        CRITTER,
+        CASTER,
 
-		// Biomes
-		FOREST,
-		CAVERN,
-		JUNGLE,
-		BLOOD_MOON,
-		OCEAN,
-		GOBLIN_ARMY,
-		MUSHROOM,
+        // Biomes
+        FOREST,
+        CAVERN,
+        JUNGLE,
+        BLOOD_MOON,
+        OCEAN,
+        GOBLIN_ARMY,
+        MUSHROOM,
 
-		// Item Subtypes
-		EQUIPMENT,
-		CONSUMABLE,
+        // Item Subtypes
+        EQUIPMENT,
+        CONSUMABLE,
 
-		// Duplicate CardTypes (for text rendering)
-		TOWNSFOLK,
-		ITEM,
+        // Duplicate CardTypes (for text rendering)
+        TOWNSFOLK,
+        ITEM,
 		EVIL,
 		OWNED,
 		SNOW,
@@ -57,9 +62,9 @@ namespace TerraTCG.Common.GameSystem.GameState
 		DESERT,
 	}
 
-	// Bot helper function, apply additional
-	// logic for whether the bot should use
-	// this item on an ally
+    // Bot helper function, apply additional
+    // logic for whether the bot should use
+    // this item on an ally
 	public delegate bool ShouldTarget(Zone zone);
 
 	// Delegate function type to check whether a given card can
@@ -67,13 +72,13 @@ namespace TerraTCG.Common.GameSystem.GameState
 	public delegate bool CanPromote(Zone zone, Card card);
 
 	public class Card
-	{
+    {
 		public string Name { get; set; }
 
-		// The mod that originated this card
+        // The mod that originated this card
 		public string Mod { get; set; } = ModContent.GetInstance<TerraTCG>().Name;
 
-		internal string FullName => $"{Mod}/{Name}";
+        internal string FullName => $"{Mod}/{Name}";
 
 		// Automatically loaded from its texture
 		public int GoreType { get; set; }
@@ -94,8 +99,8 @@ namespace TerraTCG.Common.GameSystem.GameState
 
 		public List<CardSubtype> SubTypes { get; set; }
 
-		internal CardSubtype SortType =>
-			(SubTypes[0] == CardSubtype.EXPERT || SubTypes[0] == CardSubtype.BOSS) ? SubTypes[1] : SubTypes[0];
+        internal CardSubtype SortType => 
+            (SubTypes[0] == CardSubtype.EXPERT || SubTypes[0] == CardSubtype.BOSS) ? SubTypes[1] : SubTypes[0];
 
 		internal CardSubtype RoleSubtype => SubTypes.Last();
 
@@ -103,20 +108,20 @@ namespace TerraTCG.Common.GameSystem.GameState
 
 		public int MoveCost { get; set; }
 
-		// Points awarded on defeating this card
+        // Points awarded on defeating this card
 		public int Points { get; set; } = 1;
 
-		// Used for cards that can only be created by other cards (eg. Nymph)
+        // Used for cards that can only be created by other cards (eg. Nymph)
 		public bool IsCollectable { get; set; } = true;
 
 		public SelectInHandAction SelectInHandAction { get; set; }
-			= (zone, player) => new DeployCreatureAction(zone, player);
+            = (zone, player) => new DeployCreatureAction(zone, player);
 		public SelectOnFieldAction SelectOnFieldAction { get; set; }
-			= (zone, player) => new MoveCardOrAttackAction(zone, player);
+            = (zone, player) => new MoveCardOrAttackAction(zone, player);
 
 		public List<Skill> Skills { get; set; }
 
-		internal bool HasSkill => (Skills?.Count ?? 0) > 0;
+        internal bool HasSkill => (Skills?.Count ?? 0) > 0;
 
 		public List<Attack> Attacks { get; set; }
 
@@ -130,13 +135,13 @@ namespace TerraTCG.Common.GameSystem.GameState
 		// ShouldRemove(GameEvent.START_TURN)
 		public Func<List<ICardModifier>> FieldModifiers { get; set; }
 
-		// Tags to help bot players decide what to do with cards
+        // Tags to help bot players decide what to do with cards
 
-		// Where to place the card on the board
+        // Where to place the card on the board
 		public ZoneRole Role { get; set; } = ZoneRole.OFFENSE;
 
 
-		// Among cards of the same type, how important is it to play this one first?
+        // Among cards of the same type, how important is it to play this one first?
 		public int Priority { get; set; } = 0;
 
 		// Helper func for the bot player that suggests whether a zone would be a good target
@@ -148,63 +153,63 @@ namespace TerraTCG.Common.GameSystem.GameState
 
 		// Func to check whether this card can evolve onto a given card on the field
 		// By default, check whether the biome and combat role match
-		public CanPromote CanPromote { get; set; } = (zone, card) =>
+		public CanPromote CanPromote { get; set; } = (zone, card) => 
 			zone.PlacedCard?.Template.SubTypes[0] == card.SubTypes[1] &&
 			zone.PlacedCard?.Template.SubTypes.Last() == card.SubTypes.Last();
 
 
-		// Localization utils
-		internal string CardName => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Name");
+        // Localization utils
+        internal string CardName => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Name");
 
-		internal string AttackName => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Attack.Name");
-		internal string AttackDescription => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Attack.Description");
-		internal string SkillName => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Skill.Name");
-		internal string SkillDescription => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Skill.Description");
+        internal string AttackName => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Attack.Name");
+        internal string AttackDescription => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Attack.Description");
+        internal string SkillName => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Skill.Name");
+        internal string SkillDescription => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Skill.Description");
 
-		internal string ModifierDescription => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Modifier.Description");
+        internal string ModifierDescription => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Modifier.Description");
 
-		internal bool HasAttackText => Language.Exists($"Mods.{Mod}.Cards.{Name}.Attack.Name");
-		internal bool HasAttackDescription => HasAttackText && Language.Exists($"Mods.{Mod}.Cards.{Name}.Attack.Description");
-		internal bool HasSkillText => Language.Exists($"Mods.{Mod}.Cards.{Name}.Skill.Name");
-		internal bool HasSkillDescription => HasSkillText && Language.Exists($"Mods.{Mod}.Cards.{Name}.Skill.Description");
-		internal bool HasModifierText => Language.Exists($"Mods.{Mod}.Cards.{Name}.Modifier.Description");
+        internal bool HasAttackText => Language.Exists($"Mods.{Mod}.Cards.{Name}.Attack.Name");
+        internal bool HasAttackDescription => HasAttackText && Language.Exists($"Mods.{Mod}.Cards.{Name}.Attack.Description");
+        internal bool HasSkillText => Language.Exists($"Mods.{Mod}.Cards.{Name}.Skill.Name");
+        internal bool HasSkillDescription => HasSkillText && Language.Exists($"Mods.{Mod}.Cards.{Name}.Skill.Description");
+        internal bool HasModifierText => Language.Exists($"Mods.{Mod}.Cards.{Name}.Modifier.Description");
 
 		internal string TypeLine => string.Join(" ",
 			SubTypes.Select(t => Language.Exists($"Mods.{Mod}.Cards.Types.{t}") ? Language.GetTextValue($"Mods.{Mod}.Cards.Types.{t}") : Language.GetTextValue($"Mods.TerraTCG.Cards.Types.{t}")));
 
-		public DrawZoneNPC DrawZoneNPC { get; set; } = CardOverlayRenderer.Instance.DefaultDrawZoneNPC;
+        public DrawZoneNPC DrawZoneNPC { get; set; } = CardOverlayRenderer.Instance.DefaultDrawZoneNPC;
 
 		// Do a search of whether any text on the card contains the search term
 		internal bool MatchesTextFilter(string textFilter)
-		{
-			var allMyText = new StringBuilder();
-			// All cards have a name and typeline
-			allMyText.Append(CardName);
-			allMyText.Append(TypeLine);
+        {
+            var allMyText = new StringBuilder();
+            // All cards have a name and typeline
+            allMyText.Append(CardName);
+            allMyText.Append(TypeLine);
 
-			// Cards variably have attacks, skills, and static modifiers
-			if (HasAttackText)
-			{
-				allMyText.Append(AttackName);
-			}
-			if (HasAttackDescription)
-			{
-				allMyText.Append(AttackDescription);
-			}
-			if (HasSkill)
-			{
-				allMyText.Append(SkillName);
-			}
-			if (HasSkillDescription)
-			{
-				allMyText.Append(SkillDescription);
-			}
-			if (HasModifierText)
-			{
-				allMyText.Append(ModifierDescription);
-			}
+            // Cards variably have attacks, skills, and static modifiers
+            if(HasAttackText)
+            {
+                allMyText.Append(AttackName);
+            }
+            if(HasAttackDescription)
+            {
+                allMyText.Append(AttackDescription);
+            }
+            if(HasSkill)
+            {
+                allMyText.Append(SkillName);
+            }
+            if (HasSkillDescription)
+            {
+                allMyText.Append(SkillDescription);
+            }
+            if(HasModifierText)
+            {
+                allMyText.Append(ModifierDescription);
+            }
 
-			return allMyText.ToString().Replace("\n", " ").Contains(textFilter, StringComparison.CurrentCultureIgnoreCase);
-		}
-	}
+            return allMyText.ToString().Replace("\n"," ").Contains(textFilter, StringComparison.CurrentCultureIgnoreCase);
+        }
+    }
 }

--- a/Common/GameSystem/GameState/Card.cs
+++ b/Common/GameSystem/GameState/Card.cs
@@ -176,6 +176,8 @@ namespace TerraTCG.Common.GameSystem.GameState
 
         internal string TypeLine => string.Join(" ", 
             SubTypes.Select(t => Language.GetTextValue($"Mods.{Mod}.Cards.Types.{t}")));
+		internal string TypeLine => string.Join(" ",
+			SubTypes.Select(t => Language.Exists($"Mods.{Mod}.Cards.Types.{t}") ? Language.GetTextValue($"Mods.{Mod}.Cards.Types.{t}") : Language.GetTextValue($"Mods.TerraTCG.Cards.Types.{t}")));
 
         public DrawZoneNPC DrawZoneNPC { get; set; } = CardOverlayRenderer.Instance.DefaultDrawZoneNPC;
 

--- a/Common/GameSystem/GameState/Card.cs
+++ b/Common/GameSystem/GameState/Card.cs
@@ -1,60 +1,55 @@
-﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using Terraria;
-using Terraria.GameContent;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using TerraTCG.Common.GameSystem.Drawing;
 using TerraTCG.Common.GameSystem.GameState.GameActions;
 using TerraTCG.Common.GameSystem.GameState.Modifiers;
-using TerraTCG.Common.Util;
 
 namespace TerraTCG.Common.GameSystem.GameState
 {
 	public enum CardType
-    {
-        CREATURE,
-        ITEM,
-        TOWNSFOLK
-    }
+	{
+		CREATURE,
+		ITEM,
+		TOWNSFOLK
+	}
 
 	public enum CardSubtype
-    {
-        // Empty value
-        NONE,
-        // Creature Supertypes
-        EXPERT,
-        BOSS,
-        // Creature Roles
-        FIGHTER,
-        SCOUT,
-        DEFENDER,
-        SLIME,
-        CRITTER,
-        CASTER,
+	{
+		// Empty value
+		NONE,
+		// Creature Supertypes
+		EXPERT,
+		BOSS,
+		// Creature Roles
+		FIGHTER,
+		SCOUT,
+		DEFENDER,
+		SLIME,
+		CRITTER,
+		CASTER,
 
-        // Biomes
-        FOREST,
-        CAVERN,
-        JUNGLE,
-        BLOOD_MOON,
-        OCEAN,
-        GOBLIN_ARMY,
-        MUSHROOM,
+		// Biomes
+		FOREST,
+		CAVERN,
+		JUNGLE,
+		BLOOD_MOON,
+		OCEAN,
+		GOBLIN_ARMY,
+		MUSHROOM,
 
-        // Item Subtypes
-        EQUIPMENT,
-        CONSUMABLE,
+		// Item Subtypes
+		EQUIPMENT,
+		CONSUMABLE,
 
-        // Duplicate CardTypes (for text rendering)
-        TOWNSFOLK,
-        ITEM,
+		// Duplicate CardTypes (for text rendering)
+		TOWNSFOLK,
+		ITEM,
 		EVIL,
 		OWNED,
 		SNOW,
@@ -62,9 +57,9 @@ namespace TerraTCG.Common.GameSystem.GameState
 		DESERT,
 	}
 
-    // Bot helper function, apply additional
-    // logic for whether the bot should use
-    // this item on an ally
+	// Bot helper function, apply additional
+	// logic for whether the bot should use
+	// this item on an ally
 	public delegate bool ShouldTarget(Zone zone);
 
 	// Delegate function type to check whether a given card can
@@ -72,13 +67,13 @@ namespace TerraTCG.Common.GameSystem.GameState
 	public delegate bool CanPromote(Zone zone, Card card);
 
 	public class Card
-    {
+	{
 		public string Name { get; set; }
 
-        // The mod that originated this card
+		// The mod that originated this card
 		public string Mod { get; set; } = ModContent.GetInstance<TerraTCG>().Name;
 
-        internal string FullName => $"{Mod}/{Name}";
+		internal string FullName => $"{Mod}/{Name}";
 
 		// Automatically loaded from its texture
 		public int GoreType { get; set; }
@@ -99,8 +94,8 @@ namespace TerraTCG.Common.GameSystem.GameState
 
 		public List<CardSubtype> SubTypes { get; set; }
 
-        internal CardSubtype SortType => 
-            (SubTypes[0] == CardSubtype.EXPERT || SubTypes[0] == CardSubtype.BOSS) ? SubTypes[1] : SubTypes[0];
+		internal CardSubtype SortType =>
+			(SubTypes[0] == CardSubtype.EXPERT || SubTypes[0] == CardSubtype.BOSS) ? SubTypes[1] : SubTypes[0];
 
 		internal CardSubtype RoleSubtype => SubTypes.Last();
 
@@ -108,20 +103,20 @@ namespace TerraTCG.Common.GameSystem.GameState
 
 		public int MoveCost { get; set; }
 
-        // Points awarded on defeating this card
+		// Points awarded on defeating this card
 		public int Points { get; set; } = 1;
 
-        // Used for cards that can only be created by other cards (eg. Nymph)
+		// Used for cards that can only be created by other cards (eg. Nymph)
 		public bool IsCollectable { get; set; } = true;
 
 		public SelectInHandAction SelectInHandAction { get; set; }
-            = (zone, player) => new DeployCreatureAction(zone, player);
+			= (zone, player) => new DeployCreatureAction(zone, player);
 		public SelectOnFieldAction SelectOnFieldAction { get; set; }
-            = (zone, player) => new MoveCardOrAttackAction(zone, player);
+			= (zone, player) => new MoveCardOrAttackAction(zone, player);
 
 		public List<Skill> Skills { get; set; }
 
-        internal bool HasSkill => (Skills?.Count ?? 0) > 0;
+		internal bool HasSkill => (Skills?.Count ?? 0) > 0;
 
 		public List<Attack> Attacks { get; set; }
 
@@ -135,13 +130,13 @@ namespace TerraTCG.Common.GameSystem.GameState
 		// ShouldRemove(GameEvent.START_TURN)
 		public Func<List<ICardModifier>> FieldModifiers { get; set; }
 
-        // Tags to help bot players decide what to do with cards
+		// Tags to help bot players decide what to do with cards
 
-        // Where to place the card on the board
+		// Where to place the card on the board
 		public ZoneRole Role { get; set; } = ZoneRole.OFFENSE;
 
 
-        // Among cards of the same type, how important is it to play this one first?
+		// Among cards of the same type, how important is it to play this one first?
 		public int Priority { get; set; } = 0;
 
 		// Helper func for the bot player that suggests whether a zone would be a good target
@@ -153,65 +148,63 @@ namespace TerraTCG.Common.GameSystem.GameState
 
 		// Func to check whether this card can evolve onto a given card on the field
 		// By default, check whether the biome and combat role match
-		public CanPromote CanPromote { get; set; } = (zone, card) => 
+		public CanPromote CanPromote { get; set; } = (zone, card) =>
 			zone.PlacedCard?.Template.SubTypes[0] == card.SubTypes[1] &&
 			zone.PlacedCard?.Template.SubTypes.Last() == card.SubTypes.Last();
 
 
-        // Localization utils
-        internal string CardName => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Name");
+		// Localization utils
+		internal string CardName => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Name");
 
-        internal string AttackName => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Attack.Name");
-        internal string AttackDescription => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Attack.Description");
-        internal string SkillName => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Skill.Name");
-        internal string SkillDescription => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Skill.Description");
+		internal string AttackName => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Attack.Name");
+		internal string AttackDescription => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Attack.Description");
+		internal string SkillName => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Skill.Name");
+		internal string SkillDescription => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Skill.Description");
 
-        internal string ModifierDescription => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Modifier.Description");
+		internal string ModifierDescription => Language.GetTextValue($"Mods.{Mod}.Cards.{Name}.Modifier.Description");
 
-        internal bool HasAttackText => Language.Exists($"Mods.{Mod}.Cards.{Name}.Attack.Name");
-        internal bool HasAttackDescription => HasAttackText && Language.Exists($"Mods.{Mod}.Cards.{Name}.Attack.Description");
-        internal bool HasSkillText => Language.Exists($"Mods.{Mod}.Cards.{Name}.Skill.Name");
-        internal bool HasSkillDescription => HasSkillText && Language.Exists($"Mods.{Mod}.Cards.{Name}.Skill.Description");
-        internal bool HasModifierText => Language.Exists($"Mods.{Mod}.Cards.{Name}.Modifier.Description");
+		internal bool HasAttackText => Language.Exists($"Mods.{Mod}.Cards.{Name}.Attack.Name");
+		internal bool HasAttackDescription => HasAttackText && Language.Exists($"Mods.{Mod}.Cards.{Name}.Attack.Description");
+		internal bool HasSkillText => Language.Exists($"Mods.{Mod}.Cards.{Name}.Skill.Name");
+		internal bool HasSkillDescription => HasSkillText && Language.Exists($"Mods.{Mod}.Cards.{Name}.Skill.Description");
+		internal bool HasModifierText => Language.Exists($"Mods.{Mod}.Cards.{Name}.Modifier.Description");
 
-        internal string TypeLine => string.Join(" ", 
-            SubTypes.Select(t => Language.GetTextValue($"Mods.{Mod}.Cards.Types.{t}")));
 		internal string TypeLine => string.Join(" ",
 			SubTypes.Select(t => Language.Exists($"Mods.{Mod}.Cards.Types.{t}") ? Language.GetTextValue($"Mods.{Mod}.Cards.Types.{t}") : Language.GetTextValue($"Mods.TerraTCG.Cards.Types.{t}")));
 
-        public DrawZoneNPC DrawZoneNPC { get; set; } = CardOverlayRenderer.Instance.DefaultDrawZoneNPC;
+		public DrawZoneNPC DrawZoneNPC { get; set; } = CardOverlayRenderer.Instance.DefaultDrawZoneNPC;
 
 		// Do a search of whether any text on the card contains the search term
 		internal bool MatchesTextFilter(string textFilter)
-        {
-            var allMyText = new StringBuilder();
-            // All cards have a name and typeline
-            allMyText.Append(CardName);
-            allMyText.Append(TypeLine);
+		{
+			var allMyText = new StringBuilder();
+			// All cards have a name and typeline
+			allMyText.Append(CardName);
+			allMyText.Append(TypeLine);
 
-            // Cards variably have attacks, skills, and static modifiers
-            if(HasAttackText)
-            {
-                allMyText.Append(AttackName);
-            }
-            if(HasAttackDescription)
-            {
-                allMyText.Append(AttackDescription);
-            }
-            if(HasSkill)
-            {
-                allMyText.Append(SkillName);
-            }
-            if (HasSkillDescription)
-            {
-                allMyText.Append(SkillDescription);
-            }
-            if(HasModifierText)
-            {
-                allMyText.Append(ModifierDescription);
-            }
+			// Cards variably have attacks, skills, and static modifiers
+			if (HasAttackText)
+			{
+				allMyText.Append(AttackName);
+			}
+			if (HasAttackDescription)
+			{
+				allMyText.Append(AttackDescription);
+			}
+			if (HasSkill)
+			{
+				allMyText.Append(SkillName);
+			}
+			if (HasSkillDescription)
+			{
+				allMyText.Append(SkillDescription);
+			}
+			if (HasModifierText)
+			{
+				allMyText.Append(ModifierDescription);
+			}
 
-            return allMyText.ToString().Replace("\n"," ").Contains(textFilter, StringComparison.CurrentCultureIgnoreCase);
-        }
-    }
+			return allMyText.ToString().Replace("\n", " ").Contains(textFilter, StringComparison.CurrentCultureIgnoreCase);
+		}
+	}
 }

--- a/Common/GameSystem/GameState/CardCollection.cs
+++ b/Common/GameSystem/GameState/CardCollection.cs
@@ -66,13 +66,10 @@ namespace TerraTCG.Common.GameSystem.GameState
 
         public void DeSerialize(List<string> cardFullNames)
         {
-            var allCards = ModContent.GetContent<BaseCardTemplate>()
-                .Select(t => t.Card);
-
             // TODO handle errors
             Cards = cardFullNames
-				.Where(fn => allCards.Any(c => c.FullName == fn))
-                .Select(fn => allCards.Where(c => c.FullName == fn).FirstOrDefault())
+				.Where(fn => CardRegistry.AllCards.Any(c => c.FullName == fn))
+                .Select(fn => CardRegistry.AllCards.Where(c => c.FullName == fn).FirstOrDefault())
                 .ToList();
         }
     }

--- a/Common/GameSystem/PackOpening/CardPools.cs
+++ b/Common/GameSystem/PackOpening/CardPools.cs
@@ -15,10 +15,9 @@ namespace TerraTCG.Common.GameSystem.PackOpening
 	internal class CardPools
 	{
 		// Cards that can appear in any pack, generally, "not good" cards
-		public static CardCollection AllCards => new()
+		public static CardCollection CollectableCards => new()
 		{
-			Cards = ModContent.GetContent<BaseCardTemplate>()
-				.Select(t => t.Card)
+			Cards = CardRegistry.AllCards
 				.Where(c=>c.IsCollectable && c.SubTypes[0] != CardSubtype.BOSS)
 				.ToList()
 		};

--- a/Common/Netcode/Packets/DecklistPacket.cs
+++ b/Common/Netcode/Packets/DecklistPacket.cs
@@ -16,22 +16,10 @@ namespace TerraTCG.Common.Netcode.Packets
 	internal class CardNetworkSync : ModSystem
 	{
 		public static CardNetworkSync Instance => ModContent.GetInstance<CardNetworkSync>();
-		// TODO *really* need a central location for this
-		private List<Card> _allCards;
-		public List<Card> AllCards
-		{
-			get
-			{
-				_allCards ??= ModContent.GetContent<BaseCardTemplate>()
-					.Select(t => t.Card)
-					.ToList();
-				return _allCards;
-			}
-		}
 
-		public static ushort Serialize(Card card) => (ushort)Instance.AllCards.IndexOf(card);
+		public static ushort Serialize(Card card) => (ushort)CardRegistry.AllCards.IndexOf(card);
 
-		public static Card Deserialize(ushort idx) => Instance.AllCards[idx];
+		public static Card Deserialize(ushort idx) => CardRegistry.AllCards[idx];
 	}
 
 	// Packet used to sync each player's ordered decklist with their opponent's client

--- a/Common/UI/DeckbuildUI/CardListFilter.cs
+++ b/Common/UI/DeckbuildUI/CardListFilter.cs
@@ -54,8 +54,6 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 
         public string FilterString { get; private set; }
 
-        private List<Card> allCards;
-
         private int visibleCount;
         private int totalCount;
 
@@ -69,11 +67,6 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 
         public override void OnInitialize()
         {
-            allCards = ModContent.GetContent<BaseCardTemplate>()
-                .Select(t=>t.Card)
-                .Where(c => c.IsCollectable)
-                .ToList();
-
             filterButtons = [];
             searchTextBox = new(Language.GetText("Mods.TerraTCG.Cards.Common.Search"))
             {
@@ -167,7 +160,7 @@ namespace TerraTCG.Common.UI.DeckbuildUI
         public override void Update(GameTime gameTime)
         {
             Main.LocalPlayer.mouseInterface = true;
-            totalCount = 2 * allCards.Count;
+            totalCount = 2 * CardRegistry.AllCards.Count;
 			visibleCount = TCGPlayer.LocalPlayer.Collection.Cards.Count;
             base.Update(gameTime);
         }

--- a/Common/UI/DeckbuildUI/DeckbuildCardList.cs
+++ b/Common/UI/DeckbuildUI/DeckbuildCardList.cs
@@ -26,6 +26,14 @@ namespace TerraTCG.Common.UI.DeckbuildUI
         {
             base.OnInitialize();
             cards = CardRegistry.AllCards
+		public void ResetCards()
+		{
+			foreach (UIElement c in Children)
+			{
+				c.Deactivate();
+			}
+			OnInitialize();
+		}
 				.Where(c => c.IsCollectable)
                 .OrderBy(t => t.SortType)
                 .ThenBy(t => t.Name)

--- a/Common/UI/DeckbuildUI/DeckbuildCardList.cs
+++ b/Common/UI/DeckbuildUI/DeckbuildCardList.cs
@@ -17,9 +17,12 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 		internal List<DeckbuildCardElement> cards;
 		private UIScrollbar scrollBar;
 
+		private bool needsReconstruction = false;
+
 		public override void OnInitialize()
 		{
 			base.OnInitialize();
+			CardRegistry.OnCardsAdded += () => needsReconstruction = true;
 			ConstructUI();
 		}
 
@@ -124,9 +127,9 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 
 		protected override void DrawChildren(SpriteBatch spriteBatch)
 		{
-			if (CardRegistry.needsReconstruction)
+			if (needsReconstruction)
 			{
-				CardRegistry.needsReconstruction = false;
+				needsReconstruction = false;
 				ReconstructUI();
 			}
 

--- a/Common/UI/DeckbuildUI/DeckbuildCardList.cs
+++ b/Common/UI/DeckbuildUI/DeckbuildCardList.cs
@@ -34,6 +34,7 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 			}
 			OnInitialize();
 		}
+			CardRegistry.CardChanges += ResetCards;
 				.Where(c => c.IsCollectable)
                 .OrderBy(t => t.SortType)
                 .ThenBy(t => t.Name)

--- a/Common/UI/DeckbuildUI/DeckbuildCardList.cs
+++ b/Common/UI/DeckbuildUI/DeckbuildCardList.cs
@@ -19,7 +19,6 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 		public override void OnInitialize()
 		{
 			base.OnInitialize();
-			CardRegistry.OnCardsAdded += ReconstructUI;
 			ConstructUI();
 		}
 
@@ -27,6 +26,7 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 		{
 			RemoveAllChildren();
 			ConstructUI();
+			CardRegistry.RequestAddCards = false;
 		}
 
 		private void ConstructUI()
@@ -114,6 +114,8 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 		public override void Update(GameTime gameTime)
 		{
 			base.Update(gameTime);
+			if (CardRegistry.RequestAddCards)
+				ReconstructUI();
 			if (IsMouseHovering)
 			{
 				Terraria.GameInput.PlayerInput.LockVanillaMouseScroll("TerraTCG");

--- a/Common/UI/DeckbuildUI/DeckbuildCardList.cs
+++ b/Common/UI/DeckbuildUI/DeckbuildCardList.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,7 +27,6 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 		{
 			RemoveAllChildren();
 			ConstructUI();
-			CardRegistry.RequestAddCards = false;
 		}
 
 		private void ConstructUI()
@@ -114,14 +114,22 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 		public override void Update(GameTime gameTime)
 		{
 			base.Update(gameTime);
-			if (CardRegistry.RequestAddCards)
-				ReconstructUI();
 			if (IsMouseHovering)
 			{
 				Terraria.GameInput.PlayerInput.LockVanillaMouseScroll("TerraTCG");
 				Main.LocalPlayer.mouseInterface = true;
 			}
 			CalculateCardPositions();
+		}
+
+		public override void Draw(SpriteBatch spriteBatch)
+		{
+			base.Draw(spriteBatch);
+			if (CardRegistry.RequestAddCards)
+			{
+				CardRegistry.RequestAddCards = false;
+				ReconstructUI();
+			}
 		}
 	}
 }

--- a/Common/UI/DeckbuildUI/DeckbuildCardList.cs
+++ b/Common/UI/DeckbuildUI/DeckbuildCardList.cs
@@ -18,8 +18,8 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 
 		public override void OnInitialize()
 		{
-			CardRegistry.OnCardsAdded += ReconstructUI;
 			base.OnInitialize();
+			CardRegistry.OnCardsAdded += ReconstructUI;
 			ConstructUI();
 		}
 

--- a/Common/UI/DeckbuildUI/DeckbuildCardList.cs
+++ b/Common/UI/DeckbuildUI/DeckbuildCardList.cs
@@ -25,9 +25,8 @@ namespace TerraTCG.Common.UI.DeckbuildUI
         public override void OnInitialize()
         {
             base.OnInitialize();
-            cards = ModContent.GetContent<BaseCardTemplate>()
-                .Select(t=>t.Card)
-                .Where(c => c.IsCollectable)
+            cards = CardRegistry.AllCards
+				.Where(c => c.IsCollectable)
                 .OrderBy(t => t.SortType)
                 .ThenBy(t => t.Name)
                 .Select(c => new DeckbuildCardElement(c))

--- a/Common/UI/DeckbuildUI/DeckbuildCardList.cs
+++ b/Common/UI/DeckbuildUI/DeckbuildCardList.cs
@@ -16,19 +16,21 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 		internal List<DeckbuildCardElement> cards;
 		private UIScrollbar scrollBar;
 
-		public void ResetCards()
-		{
-			foreach (UIElement c in Children)
-			{
-				c.Deactivate();
-			}
-			OnInitialize();
-		}
-
 		public override void OnInitialize()
 		{
-			CardRegistry.OnCardsAdded += ResetCards;
+			CardRegistry.OnCardsAdded += ReconstructUI;
 			base.OnInitialize();
+			ConstructUI();
+		}
+
+		public void ReconstructUI()
+		{
+			RemoveAllChildren();
+			ConstructUI();
+		}
+
+		private void ConstructUI()
+		{
 			cards = CardRegistry.AllCards
 				.Where(c => c.IsCollectable)
 				.OrderBy(t => t.SortType)

--- a/Common/UI/DeckbuildUI/DeckbuildCardList.cs
+++ b/Common/UI/DeckbuildUI/DeckbuildCardList.cs
@@ -2,30 +2,20 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
 using Terraria.GameContent.UI.Elements;
-using Terraria.ModLoader;
 using Terraria.UI;
 using TerraTCG.Common.GameSystem;
-using TerraTCG.Common.GameSystem.CardData;
-using TerraTCG.Common.GameSystem.GameState;
 using TerraTCG.Common.UI.GameFieldUI;
 using static TerraTCG.Common.UI.DeckbuildUI.DeckbuildCardElement;
 
 namespace TerraTCG.Common.UI.DeckbuildUI
 {
-    internal class DeckbuildCardList : UIPanel
-    {
-        internal List<DeckbuildCardElement> cards;
-        private UIScrollbar scrollBar;
+	internal class DeckbuildCardList : UIPanel
+	{
+		internal List<DeckbuildCardElement> cards;
+		private UIScrollbar scrollBar;
 
-        public override void OnInitialize()
-        {
-            base.OnInitialize();
-            cards = CardRegistry.AllCards
 		public void ResetCards()
 		{
 			foreach (UIElement c in Children)
@@ -34,94 +24,100 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 			}
 			OnInitialize();
 		}
+
+		public override void OnInitialize()
+		{
 			CardRegistry.CardChanges += ResetCards;
+			base.OnInitialize();
+			cards = CardRegistry.AllCards
 				.Where(c => c.IsCollectable)
-                .OrderBy(t => t.SortType)
-                .ThenBy(t => t.Name)
-                .Select(c => new DeckbuildCardElement(c))
-                .ToList();
+				.OrderBy(t => t.SortType)
+				.ThenBy(t => t.Name)
+				.Select(c => new DeckbuildCardElement(c))
+				.ToList();
 
-            foreach (var card in cards)
-            {
-                Append(card);
-            }
-            scrollBar = new UIScrollbar
-            {
-                HAlign = 1f
-            };
-            scrollBar.Height.Percent = 1f;
-            Append(scrollBar);
+			foreach (var card in cards)
+			{
+				Append(card);
+			}
+			scrollBar = new UIScrollbar
+			{
+				HAlign = 1f
+			};
+			scrollBar.Height.Percent = 1f;
+			Append(scrollBar);
 
-            OnScrollWheel += DeckbuildCardList_OnScrollWheel;
-        }
+			OnScrollWheel += DeckbuildCardList_OnScrollWheel;
+		}
 
-        private void DeckbuildCardList_OnScrollWheel(UIScrollWheelEvent evt, UIElement listeningElement)
-        {
-            if(evt.ScrollWheelValue > 0)
-            {
-                scrollBar.ViewPosition = Math.Max(0, scrollBar.ViewPosition - 0.5f);
-            } else
-            {
-                scrollBar.ViewPosition = Math.Min(19, scrollBar.ViewPosition + 0.5f);
-            }
-        }
+		private void DeckbuildCardList_OnScrollWheel(UIScrollWheelEvent evt, UIElement listeningElement)
+		{
+			if (evt.ScrollWheelValue > 0)
+			{
+				scrollBar.ViewPosition = Math.Max(0, scrollBar.ViewPosition - 0.5f);
+			}
+			else
+			{
+				scrollBar.ViewPosition = Math.Min(19, scrollBar.ViewPosition + 0.5f);
+			}
+		}
 
-        public void ResetScroll()
-        {
-            scrollBar.ViewPosition = 0f;
-        }
+		public void ResetScroll()
+		{
+			scrollBar.ViewPosition = 0f;
+		}
 
-        private List<DeckbuildCardElement> GetVisibleCards()
-        {
-            // TODO is this the best way to pass data between sibling elements
-            return ((DeckbuildState)Parent).FilterCards(cards).ToList();
-        }
-        private void CalculateCardPositions()
-        {
-            int CARDS_PER_ROW = 5;
-            var scrollOffset = scrollBar.ViewPosition / 19f; // empirically determined to be [0->20)
-            var visibleCards = GetVisibleCards();
-            var totalRowCount = (visibleCards.Count / CARDS_PER_ROW);
-            if(cards.Count % CARDS_PER_ROW != 0)
-            {
-                totalRowCount += 1;
-            }
+		private List<DeckbuildCardElement> GetVisibleCards()
+		{
+			// TODO is this the best way to pass data between sibling elements
+			return ((DeckbuildState)Parent).FilterCards(cards).ToList();
+		}
+		private void CalculateCardPositions()
+		{
+			int CARDS_PER_ROW = 5;
+			var scrollOffset = scrollBar.ViewPosition / 19f; // empirically determined to be [0->20)
+			var visibleCards = GetVisibleCards();
+			var totalRowCount = (visibleCards.Count / CARDS_PER_ROW);
+			if (cards.Count % CARDS_PER_ROW != 0)
+			{
+				totalRowCount += 1;
+			}
 
-            var visibleRows = DeckbuildState.GetWindowHeight().Item1;
-            var maxScroll = Math.Max(0, totalRowCount - visibleRows);
+			var visibleRows = DeckbuildState.GetWindowHeight().Item1;
+			var maxScroll = Math.Max(0, totalRowCount - visibleRows);
 
-            var topRow = (int)MathHelper.Lerp(0, maxScroll, scrollOffset);
-            var yOffset = topRow * (int)(CARD_HEIGHT * CARD_SCALE + CARD_MARGIN);
+			var topRow = (int)MathHelper.Lerp(0, maxScroll, scrollOffset);
+			var yOffset = topRow * (int)(CARD_HEIGHT * CARD_SCALE + CARD_MARGIN);
 
-            for(int i = 0; i < visibleCards.Count; i++)
-            {
-                int row = i / CARDS_PER_ROW;
-                int col = i % CARDS_PER_ROW;
-                GameFieldState.SetRectangle(visibleCards[i],
-                    col * (CARD_WIDTH * CARD_SCALE + CARD_MARGIN),
-                    row * (CARD_HEIGHT * CARD_SCALE + CARD_MARGIN) - yOffset,
-                    CARD_WIDTH * CARD_SCALE,
-                    CARD_HEIGHT * CARD_SCALE);
-            }
-            var invisibleCards = cards.Except(visibleCards);
-            // Push the non-visible cards off the bottom of the screen
-            // so that their own bounds-checking code hides them
-            foreach(var card in invisibleCards)
-            {
-                GameFieldState.SetRectangle(card, 0, Height.Pixels + 5);
-            }
+			for (int i = 0; i < visibleCards.Count; i++)
+			{
+				int row = i / CARDS_PER_ROW;
+				int col = i % CARDS_PER_ROW;
+				GameFieldState.SetRectangle(visibleCards[i],
+					col * (CARD_WIDTH * CARD_SCALE + CARD_MARGIN),
+					row * (CARD_HEIGHT * CARD_SCALE + CARD_MARGIN) - yOffset,
+					CARD_WIDTH * CARD_SCALE,
+					CARD_HEIGHT * CARD_SCALE);
+			}
+			var invisibleCards = cards.Except(visibleCards);
+			// Push the non-visible cards off the bottom of the screen
+			// so that their own bounds-checking code hides them
+			foreach (var card in invisibleCards)
+			{
+				GameFieldState.SetRectangle(card, 0, Height.Pixels + 5);
+			}
 
-        }
+		}
 
-        public override void Update(GameTime gameTime)
-        {
-            base.Update(gameTime);
-            if (IsMouseHovering)
-            {
-                Terraria.GameInput.PlayerInput.LockVanillaMouseScroll("TerraTCG");
-                Main.LocalPlayer.mouseInterface = true;
-            }
-            CalculateCardPositions();
-        }
-    }
+		public override void Update(GameTime gameTime)
+		{
+			base.Update(gameTime);
+			if (IsMouseHovering)
+			{
+				Terraria.GameInput.PlayerInput.LockVanillaMouseScroll("TerraTCG");
+				Main.LocalPlayer.mouseInterface = true;
+			}
+			CalculateCardPositions();
+		}
+	}
 }

--- a/Common/UI/DeckbuildUI/DeckbuildCardList.cs
+++ b/Common/UI/DeckbuildUI/DeckbuildCardList.cs
@@ -17,12 +17,9 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 		internal List<DeckbuildCardElement> cards;
 		private UIScrollbar scrollBar;
 
-		private bool needsReconstruction = false;
-
 		public override void OnInitialize()
 		{
 			base.OnInitialize();
-			CardRegistry.OnCardsAdded += () => needsReconstruction = true;
 			ConstructUI();
 		}
 
@@ -127,9 +124,9 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 
 		protected override void DrawChildren(SpriteBatch spriteBatch)
 		{
-			if (needsReconstruction)
+			if (CardRegistry.needsReconstruction)
 			{
-				needsReconstruction = false;
+				CardRegistry.needsReconstruction = false;
 				ReconstructUI();
 			}
 

--- a/Common/UI/DeckbuildUI/DeckbuildCardList.cs
+++ b/Common/UI/DeckbuildUI/DeckbuildCardList.cs
@@ -27,7 +27,7 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 
 		public override void OnInitialize()
 		{
-			CardRegistry.CardChanges += ResetCards;
+			CardRegistry.OnCardsAdded += ResetCards;
 			base.OnInitialize();
 			cards = CardRegistry.AllCards
 				.Where(c => c.IsCollectable)

--- a/Common/UI/DeckbuildUI/DeckbuildCardList.cs
+++ b/Common/UI/DeckbuildUI/DeckbuildCardList.cs
@@ -17,9 +17,12 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 		internal List<DeckbuildCardElement> cards;
 		private UIScrollbar scrollBar;
 
+		private bool needsReconstruction = false;
+
 		public override void OnInitialize()
 		{
 			base.OnInitialize();
+			CardRegistry.OnCardsAdded += () => needsReconstruction = true;
 			ConstructUI();
 		}
 
@@ -122,14 +125,15 @@ namespace TerraTCG.Common.UI.DeckbuildUI
 			CalculateCardPositions();
 		}
 
-		public override void Draw(SpriteBatch spriteBatch)
+		protected override void DrawChildren(SpriteBatch spriteBatch)
 		{
-			base.Draw(spriteBatch);
-			if (CardRegistry.RequestAddCards)
+			if (needsReconstruction)
 			{
-				CardRegistry.RequestAddCards = false;
+				needsReconstruction = false;
 				ReconstructUI();
 			}
+
+			base.DrawChildren(spriteBatch);
 		}
 	}
 }

--- a/Common/UI/GameFieldUI/OpponentHandElement.cs
+++ b/Common/UI/GameFieldUI/OpponentHandElement.cs
@@ -35,8 +35,7 @@ namespace TerraTCG.Common.UI.GameFieldUI
 
 		private void DrawBossBehindHand(SpriteBatch spriteBatch, int bossId)
 		{
-			var bossCard = ModContent.GetContent<BaseCardTemplate>()
-				.Select(c => c.Card)
+			var bossCard = CardRegistry.AllCards
 				.Where(c => c.NPCID == bossId)
 				.FirstOrDefault();
 			// check the vertical clearance above the hand to see if there's enough

--- a/build.txt
+++ b/build.txt
@@ -1,5 +1,5 @@
-displayName = TerraTCG: PvP Update!
-author = billybobmcbo
+displayName = [Unofficial]TerraTCG
+author = [Original Author]billybobmcbo,[Fork Author]katudonsan,eva828
 version = 1.2.0
 sortAfter = DialogueTweak
 homepage = https://forums.terraria.org/index.php?threads/terratcg-the-terraria-collectible-card-game.140791/

--- a/build.txt
+++ b/build.txt
@@ -1,5 +1,5 @@
-displayName = [Unofficial]TerraTCG
-author = [Original Author]billybobmcbo,[Fork Author]katudonsan,eva828
+displayName = TerraTCG: PvP Update!
+author = billybobmcbo
 version = 1.2.0
 sortAfter = DialogueTweak
 homepage = https://forums.terraria.org/index.php?threads/terratcg-the-terraria-collectible-card-game.140791/


### PR DESCRIPTION
各問題に於ける対処
１：カードそのものを内部データに追加することに関して
→PostSetupContentsにおいて実行、Build.txtでSortAfterにしたところ、内部データ上の追加を確認
 
２：内部データの追加に対して表示上データ＝カードがＵＩに追加されない問題の解決
→入手可能なカード（　≠　全カード）に対するカード追加も全カード追加の命令時に行う。
さらに、デッキリストＵＩをリセットする関数をコールバックに登録したイベントをレジストリ側に用意して、
カードを追加する度にイベントが発火してInitが再度実行され、ＵＩがリセットされるようにする。
 
３：外部カードのローカライズがおかしくなる
→試験的に「アドオン側にないローカライズはＴＣＧ側にもないか確かめる」という文をサブタイプに構築